### PR TITLE
Improve visibility of bottom map tab

### DIFF
--- a/mobile/src/navigation/MainTabs.tsx
+++ b/mobile/src/navigation/MainTabs.tsx
@@ -28,13 +28,39 @@ const MainTabs = (): JSX.Element => {
         headerShown: false,
         tabBarActiveTintColor: '#2563eb',
         tabBarInactiveTintColor: '#6b7280',
+        tabBarLabelStyle: {
+          fontSize: 12,
+          fontWeight: '600',
+          marginBottom: 4
+        },
+        tabBarStyle: {
+          backgroundColor: '#ffffff',
+          borderTopWidth: 1,
+          borderTopColor: '#e5e7eb',
+          height: 64,
+          paddingVertical: 6
+        },
         tabBarIcon: ({ color, size }) => (
           <Ionicons name={iconNameForRoute(route.name)} size={size} color={color} />
         )
       })}
     >
-      <Tab.Screen name="Posts" component={PostListScreen} />
-      <Tab.Screen name="Map" component={PostMapScreen} />
+      <Tab.Screen
+        name="Posts"
+        component={PostListScreen}
+        options={{
+          tabBarLabel: 'Feed',
+          tabBarTestID: 'feed-tab'
+        }}
+      />
+      <Tab.Screen
+        name="Map"
+        component={PostMapScreen}
+        options={{
+          tabBarLabel: 'Map View',
+          tabBarTestID: 'map-tab'
+        }}
+      />
     </Tab.Navigator>
   );
 };


### PR DESCRIPTION
## Summary
- style the bottom tab bar to ensure it stands out against the screen background
- add explicit labels and test identifiers for the feed and map view tabs so the map entry point is easy to spot

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127892ea548333a6b9869f04d2db96)